### PR TITLE
don't allow unicode, convert unicode to str when creating String fields

### DIFF
--- a/kitty/model/low_level/encoder.py
+++ b/kitty/model/low_level/encoder.py
@@ -29,7 +29,6 @@ There are three families of encoders:
     Used to encode fields that inherit from BitField or contain BitField (UInt8, Size, Checksum etc.)
     Those encoders are also refferred to as Int Encoders.
 '''
-import types
 from bitstring import Bits, BitArray
 from kitty.core import kassert, KittyException
 
@@ -63,7 +62,7 @@ class StrEncoder(object):
         :type value: ``str``
         :param value: value to encode
         '''
-        kassert.is_of_types(value, types.StringTypes)
+        kassert.is_of_types(value, str)
         return Bits(bytes=value)
 
 
@@ -79,7 +78,7 @@ class StrFuncEncoder(StrEncoder):
         self._func = func
 
     def encode(self, value):
-        kassert.is_of_types(value, types.StringTypes)
+        kassert.is_of_types(value, str)
         encoded = self._func(value)
         return Bits(bytes=encoded)
 
@@ -100,7 +99,7 @@ class StrEncodeEncoder(StrEncoder):
         '''
         :param value: value to encode
         '''
-        kassert.is_of_types(value, types.StringTypes)
+        kassert.is_of_types(value, str)
         try:
             encoded = value.encode(self._encoding)
         except UnicodeError:
@@ -122,7 +121,7 @@ class StrBase64NoNewLineEncoder(StrEncoder):
         '''
         :param value: value to encode
         '''
-        kassert.is_of_types(value, types.StringTypes)
+        kassert.is_of_types(value, str)
         encoded = value.encode('base64')
         if encoded:
             encoded = encoded[:-1]
@@ -138,7 +137,7 @@ class StrNullTerminatedEncoder(StrEncoder):
         '''
         :param value: value to encode
         '''
-        kassert.is_of_types(value, types.StringTypes)
+        kassert.is_of_types(value, str)
         encoded = value + '\x00'
         return Bits(bytes=encoded)
 

--- a/kitty/model/low_level/field.py
+++ b/kitty/model/low_level/field.py
@@ -410,6 +410,8 @@ class String(_LibraryField):
                 String('this is the default value', max_size=5)
         '''
         self._max_size = None if max_size is None else max_size
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
         super(String, self).__init__(value=value, encoder=encoder, fuzzable=fuzzable, name=name)
 
     def _get_local_lib(self):


### PR DESCRIPTION
Misunderstanding about unicode vs. str caused some problems when unicode variables were provided (by json tests in katnip).

Since Kitty uses byte strings in multiple places, we don't need unicode as far as I can tell. So now encoders assert the types to 'str' and not types.StringTypes, and the String __init__ converts unicode to utf-8 strings.