### PR TITLE
bugfix: [WebInterface] fixed response to API requests

### DIFF
--- a/kitty/interfaces/web.py
+++ b/kitty/interfaces/web.py
@@ -184,7 +184,7 @@ class _WebInterfaceHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         elif path == 'action/resume':
             response = ''
             self._resume_fuzzer()
-        if response:
+        if response is not None:
             self.send_response(200)
             self.send_header('Content-type', data_type)
             self.end_headers()
@@ -242,7 +242,7 @@ class _WebInterfaceHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     response = endpoints[endpoint]()
                     break
 
-        if response:
+        if response is not None:
             self.wfile.write(response)
         else:
             self.send_response(401)


### PR DESCRIPTION
If the response was empty, the web server didn't return data at all, instead of writing empty data, and it also sent 401 status, fixed that to be the case only if the response is None, not if it's empty.