### PR TITLE
logging: log that alive only if previously logged that not alive

### DIFF
--- a/kitty/core/actor.py
+++ b/kitty/core/actor.py
@@ -78,8 +78,8 @@ class KittyActor(KittyObject):
                 last_log = time.time()
                 self.logger.warn('waiting for target to be alive')
             time.sleep(self.victim_alive_check_delay)
-        else:
-            self.logger.info('target is now alive')
+        if last_log > 0: # only if we logged that we're waiting, should we log that we're now alive
+            self.logger.warn('target is now alive')
 
     def post_test(self):
         '''


### PR DESCRIPTION
also change the to warn, so that both log messages (alive/not-alive) match