### PR TITLE
[DataModel] Removed offset information

### DIFF
--- a/kitty/model/low_level/field.py
+++ b/kitty/model/low_level/field.py
@@ -61,39 +61,11 @@ class BaseField(KittyObject):
         self._current_rendered = self._default_rendered
         self._current_index = -1
         self._enclosing = None
-        self._offset = None
         self._initialized = False
         self._hash = None
 
-    def set_offset(self, offset, ctx=None):
-        '''
-        Set the offset of the field
-
-        :param offset: the offset to set
-        :param ctx: rendering context in which the method was called
-        :return: the length of the container
-        '''
-        self._initialize()
-        self._offset = offset
-        return self.get_length(ctx)
-
     def _mutating(self):
         return self._current_index != -1
-
-    def get_offset(self):
-        '''
-        Get the offset of the field
-
-        :return: the length of the container
-        '''
-        return self._offset
-
-    def get_length(self, ctx):
-        '''
-        :param ctx: rendering context in which the method was called
-        :return: the length of the field
-        '''
-        return len(self.render(ctx))
 
     def set_current_value(self, value):
         '''
@@ -189,7 +161,6 @@ class BaseField(KittyObject):
         self._current_index = -1
         self._current_value = self._default_value
         self._current_rendered = self._default_rendered
-        self._offset = None if self._enclosing else 0
 
     def _mutate(self):
         '''
@@ -224,7 +195,6 @@ class BaseField(KittyObject):
         info['value/rendered/length/bits'] = len(self._current_rendered)
         info['value/rendered/length/bytes'] = len(self._current_rendered.tobytes())
         info['value/default'] = repr(self._default_value)
-        info['value/offset'] = self.get_offset()
         info['mutation/total number'] = self._num_mutations
         info['mutation/current index'] = self._current_index
         info['mutation/mutating'] = self._mutating()

--- a/tests/test_model_low_level_container.py
+++ b/tests/test_model_low_level_container.py
@@ -232,7 +232,7 @@ class ContainerTest(BaseTestCase):
                 self.assertEqual(container.get_rendered_fields(), [])
 
     @metaTest
-    def testSetOffsetPersist(self):
+    def _testSetOffsetPersist(self):
         offset = 1000
         uut = Container(name='uut', fields=[String('abc'), String('def')])
         uut.set_offset(offset)

--- a/tests/test_model_low_level_fields.py
+++ b/tests/test_model_low_level_fields.py
@@ -576,7 +576,7 @@ class ValueTestCase(BaseTestCase):
                 self.assertEqual(field.get_rendered_fields(), [])
 
     @metaTest
-    def testCorrectOffsetIsSetFirstFieldSingleLevel(self):
+    def _testCorrectOffsetIsSetFirstFieldSingleLevel(self):
         uut = self.get_default_field()
         con = Container(name='container', fields=[uut, String('abcd')])
         con.render()
@@ -586,7 +586,7 @@ class ValueTestCase(BaseTestCase):
             self.assertEqual(uut.get_offset(), 0)
 
     @metaTest
-    def testCorrectOffsetIsSetMiddleFieldSingleLevel(self):
+    def _testCorrectOffsetIsSetMiddleFieldSingleLevel(self):
         uut = self.get_default_field()
         first_field = String('Reykjavik', name='first_field')
         con = Container(name='container', fields=[first_field, uut])
@@ -597,7 +597,7 @@ class ValueTestCase(BaseTestCase):
             self.assertEqual(uut.get_offset(), len(first_field.render()))
 
     @metaTest
-    def testCorrectOffsetIsSetMiddleFieldMultiLevel(self):
+    def _testCorrectOffsetIsSetMiddleFieldMultiLevel(self):
         uut = self.get_default_field()
         first_field = String('Reykjavik', name='first_field')
         second_field = String('Kópavogur', name='second_field')


### PR DESCRIPTION
The offset information that was added to kitty seriously slowed it in
some cases. Since there is no implementation for offset-based fields
yet, I removed this functionality, and kitty is (kinda) fast again.