### PR TITLE
Make '/' as root path when using absolute name in field

### DIFF
--- a/kitty/model/low_level/field.py
+++ b/kitty/model/low_level/field.py
@@ -258,11 +258,14 @@ class BaseField(KittyObject):
         :raises: KittyException if field could not be resolved
         '''
         current = self
-        while current.enclosing:
-            current = current.enclosing
-        components = name.split('/')[2:]
-        for component in components:
-            current = current.get_field_by_name(component)
+        if name == '/':
+            return current
+        else:
+            while current.enclosing:
+                current = current.enclosing
+            components = name.split('/')[1:]
+            for component in components:
+                current = current.get_field_by_name(component)
         return current
 
     def get_field_by_name(self, name):

--- a/kitty/model/low_level/field.py
+++ b/kitty/model/low_level/field.py
@@ -258,11 +258,11 @@ class BaseField(KittyObject):
         :raises: KittyException if field could not be resolved
         '''
         current = self
+        while current.enclosing:
+            current = current.enclosing
         if name == '/':
             return current
         else:
-            while current.enclosing:
-                current = current.enclosing
             components = name.split('/')[1:]
             for component in components:
                 current = current.get_field_by_name(component)

--- a/tests/test_model_low_level_calculated.py
+++ b/tests/test_model_low_level_calculated.py
@@ -83,7 +83,7 @@ class CalculatedTestCase(BaseTestCase):
     @metaTest
     def testAbsoluteNameExists(self):
         original_field = self.get_original_field()
-        absolute_name = '/A/B/C/' + original_field.get_name()
+        absolute_name = '/B/C/' + original_field.get_name()
         self.depends_on_name = absolute_name
         calculated_field = self.get_default_field()
         container = Container(name='A', fields=[
@@ -105,7 +105,7 @@ class CalculatedTestCase(BaseTestCase):
     @metaTest
     def testAbsoluteNameDoesNotExist(self):
         original_field = self.get_original_field()
-        absolute_name = '/A/B/' + original_field.get_name()
+        absolute_name = '/B/' + original_field.get_name()
         self.depends_on_name = absolute_name
         calculated_field = self.get_default_field()
         container = Container(name='A', fields=[
@@ -438,7 +438,7 @@ class OffsetTests(BaseTestCase):
         self.assertEqual(32, uut_val)
 
     def testResolveFieldByAbsoluteName(self):
-        self.target_field = '/A/B/C/to'
+        self.target_field = '/B/C/to'
         uut = self.get_default_field()
         container = Container(name='A', fields=[
             uut,
@@ -545,7 +545,7 @@ class AbsoluteOffsetTests(BaseTestCase):
             self.assertEqual(len(pre_field.render()) + 5, uut_val)
 
     def testResolveFieldByAbsoluteName(self):
-        self.target_field = '/A/B/C/to'
+        self.target_field = '/B/C/to'
         uut = self.get_default_field()
         container = Container(name='A', fields=[
             uut,

--- a/tests/test_model_low_level_full.py
+++ b/tests/test_model_low_level_full.py
@@ -91,7 +91,7 @@ class ComplexTest(BaseTestCase):
     def testInclusiveSizeOfPacketWithHashAtTheEnd(self):
         container = Container(name='full packet', fields=[
             Container(name='hashed part', fields=[
-                SizeInBytes(name='packet size', sized_field='/full_packet', length=32, fuzzable=False, encoder=ENC_INT_BE),
+                SizeInBytes(name='packet size', sized_field='/', length=32, fuzzable=False, encoder=ENC_INT_BE),
                 String(name='some string', value='aaa'),
             ]),
             Sha256(name='hash', depends_on='hashed part', fuzzable=False)


### PR DESCRIPTION
Make '/' as root path when using absolute name in field.