### PR TITLE
[docs] fix typos in server_fuzzing.rst

### DIFF
--- a/docs/source/tutorials/server_fuzzing.rst
+++ b/docs/source/tutorials/server_fuzzing.rst
@@ -397,7 +397,7 @@ class definition and constructor
             :param process_args: arguments to pass to the process
             :param logger: logger for this object (default: None)
             '''
-            super(ClientProcessController, self).__init__(name, logger)
+            super(LocalProcessController, self).__init__(name, logger)
             assert(process_path)
             assert(os.path.exists(process_path))
             self._process_path = process_path
@@ -417,6 +417,8 @@ pre\_test
 
         def pre_test(self, test_num):
             '''start the victim'''
+            ## call the super
+            super(LocalProcessController, self).post_test()
             ## stop the process if it still runs for some reason
             if self._process:
                 self._stop_process()
@@ -451,7 +453,7 @@ post\_test
             self.report.add('failed', self._process.returncode != 0)
             self._process = None
             ## call the super
-            super(ClientProcessController, self).post_test()
+            super(LocalProcessController, self).post_test()
 
 When all fuzzing is over, we perform the ``teardown``:
 
@@ -466,7 +468,7 @@ teardown
     '''
             self._stop_process()
             self._process = None
-            super(ClientProcessController, self).teardown()
+            super(LocalProcessController, self).teardown()
 
 Finally, here is the implementation of the ``_stop_process`` method
 
@@ -487,4 +489,3 @@ Finally, here is the implementation of the ``_stop_process`` method
 
         def _is_victim_alive(self):
             return self._process and (self._process.poll() is None)
-

--- a/docs/source/tutorials/server_fuzzing.rst
+++ b/docs/source/tutorials/server_fuzzing.rst
@@ -102,10 +102,10 @@ Data model, version 2
         String('HTTP', name='protocol name'),       # 3.a Protocol Name - a string with the value "HTTP"
         Delimiter('/', name='fws1'),                # 3.b The '/' after "HTTP"
         Dword(1, name='major version',              # 3.c Major Version - a number with the value 1
-              encoder=ENC_INT_DEC)                  # encode the major version as decimal number
+              encoder=ENC_INT_DEC),                 # encode the major version as decimal number
         Delimiter('.', name='dot1'),                # 3.d The '.' between 1 and 1
-        Dword(1, name='major version',              # 3.e Minor Version - a number with the value 1
-              encoder=ENC_INT_DEC)                  # encode the minor version as decimal number
+        Dword(1, name='minor version',              # 3.e Minor Version - a number with the value 1
+              encoder=ENC_INT_DEC),                 # encode the minor version as decimal number
         Delimiter('\r\n\r\n', name='eom')           # 4. The double "new lines" ("\r\n\r\n") at the end of the request
     ])
 
@@ -154,10 +154,10 @@ Data model, version 3
         String('HTTP', name='protocol name'),           # 3.a Protocol Name - a string with the value "HTTP"
         Delimiter('/', name='fws1'),                    # 3.b The '/' after "HTTP"
         Dword(1, name='major version',                  # 3.c Major Version - a number with the value 1
-              encoder=ENC_INT_DEC)                      # encode the major version as decimal number
+              encoder=ENC_INT_DEC),                     # encode the major version as decimal number
         Delimiter('.', name='dot1'),                    # 3.d The '.' between 1 and 1
-        Dword(1, name='major version',                  # 3.e Minor Version - a number with the value 1
-              encoder=ENC_INT_DEC)                      # encode the minor version as decimal number
+        Dword(1, name='minor version',                  # 3.e Minor Version - a number with the value 1
+              encoder=ENC_INT_DEC),                     # encode the minor version as decimal number
         Static('\r\n\r\n', name='eom')                  # 4. The double "new lines" ("\r\n\r\n") at the end of the request
     ])
 
@@ -273,9 +273,9 @@ pre\_test and post\_test
 .. code:: python
 
         def pre_test(self, test_num):
-        '''
-        prepare to the test, create a socket
-        '''
+            '''
+            prepare to the test, create a socket
+            '''
             ## call the super (report preparation etc.)
             super(TcpTarget, self).pre_test(test_num)
             ## only create a socket if we don't have one
@@ -418,7 +418,7 @@ pre\_test
         def pre_test(self, test_num):
             '''start the victim'''
             ## call the super
-            super(LocalProcessController, self).post_test()
+            super(LocalProcessController, self).pre_test(test_num)
             ## stop the process if it still runs for some reason
             if self._process:
                 self._stop_process()
@@ -464,8 +464,8 @@ teardown
 
         def teardown(self):
             '''
-    Called at the end of the fuzzing session, override with victim teardown
-    '''
+            Called at the end of the fuzzing session, override with victim teardown
+            '''
             self._stop_process()
             self._process = None
             super(LocalProcessController, self).teardown()


### PR DESCRIPTION
Corrected the example snippets to use the correct names in super() to match the class name, and also added the missing super call in "pre_test"