### PR TITLE
Serverfuzzer: call edge.callback() after receiving response

### DIFF
--- a/kitty/fuzzers/server.py
+++ b/kitty/fuzzers/server.py
@@ -66,12 +66,12 @@ class ServerFuzzer(BaseFuzzer):
         self._test_info()
         resp = None
         for edge in sequence:
-            if edge.callback:
-                edge.callback(self, edge, resp)
             session_data = self.target.get_session_data()
             node = edge.dst
             node.set_session_data(session_data)
             resp = self._transmit(node)
+            if edge.callback:
+                edge.callback(self, edge, resp)
         return self._post_test()
 
     def _transmit(self, node):


### PR DESCRIPTION
Before, the edge.callback function would be called before the response was received, when it was the first edge in the sequence, which meant the callback function would be called with None as response instead of the real response. This commit moves the callback call down so the first response in the sequence will be the correct one and not None.

This should fix #84 