### PR TITLE
Remove count from transmission subreport title

### DIFF
--- a/kitty/targets/server.py
+++ b/kitty/targets/server.py
@@ -77,11 +77,12 @@ class ServerTarget(BaseTarget):
         :return: the response (if received)
         '''
         response = None
-        trans_report_name = 'transmission_0x%04x' % self.transmission_count
+        trans_report_name = 'transmission'
         trans_report = Report(trans_report_name)
         self.transmission_report = trans_report
         self.report.add(trans_report_name, trans_report)
         try:
+            trans_report.add('index', self.transmission_count)
             trans_report.add('request (hex)', hexlify(payload).decode())
             trans_report.add('request (raw)', '%s' % payload)
             trans_report.add('request length', len(payload))


### PR DESCRIPTION
Move the transmission count number from the subreport title into its own key-value pair in the report.
The reason is that it's unnecessarily difficult to find the "transmission" subreport because you need to know the index number.
By naming the subreport just "transmission", you can always retrieve it with report["transmission"], instead of finding the keyname first.