### PR TITLE
Fix broken APIs

### DIFF
--- a/kitty/core/threading_utils.py
+++ b/kitty/core/threading_utils.py
@@ -69,7 +69,7 @@ class LoopFuncThread(threading.Thread):
         '''
         run the the function in a loop until stoped
         '''
-        while not self._stop_event.isSet():
+        while not self._stop_event.is_set():
             self._func(*self._args)
 
     def stop(self):
@@ -80,5 +80,5 @@ class LoopFuncThread(threading.Thread):
         if self._func_stop_event is not None:
             self._func_stop_event.set()
         self.join(timeout=1)
-        if self.isAlive():
+        if self.is_alive():
             print('Failed to stop thread')

--- a/kitty/interfaces/base.py
+++ b/kitty/interfaces/base.py
@@ -75,7 +75,7 @@ class BaseInterface(KittyObject):
         :return: whether current state is paused
         '''
         assert(self._continue_event)
-        return not self._continue_event.isSet()
+        return not self._continue_event.is_set()
 
     def resume(self):
         '''

--- a/tests/test_model_low_level_container.py
+++ b/tests/test_model_low_level_container.py
@@ -56,13 +56,10 @@ class ContainerTest(BaseTestCase):
         for f in all_fields:
             field_default_values.append(f.render())
         fields_mutations = []
+        joiner = Bits(0)
         for i, field in enumerate(all_fields):
-            prefix = sum(field_default_values[:i])
-            postfix = sum(field_default_values[i + 1:])
-            if prefix == 0:
-                prefix = Bits()
-            if postfix == 0:
-                postfix = Bits()
+            prefix = joiner.join(field_default_values[:i])
+            postfix = joiner.join(field_default_values[i + 1:])
             while field.mutate():
                 fields_mutations.append(prefix + field.render() + postfix)
             field.reset()
@@ -554,15 +551,12 @@ class RepeatTest(ContainerTest):
 
         field_default_values = [field.render() for field in fields]
         fields_mutations = []
+        joiner = Bits(0)
         for i in range(min_times, max_times, step):
-            fields_mutations.append(sum(field_default_values) * i)
+            fields_mutations.append(joiner.join(field_default_values) * i)
         for j, field in enumerate(fields):
-            prefix = sum(field_default_values[:j])
-            postfix = sum(field_default_values[j + 1:])
-            if prefix == 0:
-                prefix = Bits()
-            if postfix == 0:
-                postfix = Bits()
+            prefix = joiner.join(field_default_values[:j])
+            postfix = joiner.join(field_default_values[j + 1:])
             while field.mutate():
                 fields_mutations.append((prefix + field.render() + postfix) * min_times)
             field.reset()


### PR DESCRIPTION
Fix several broken APIs for python 3.11:
1. tests - use of "joiner" `Bits()` object instead of sum
2. threading related apis: `isSet` -> `is_set`, `isAlive` -> `is_alive`